### PR TITLE
fix: Update connector SQL query and related part in README.md

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -35,6 +35,20 @@ docker compose -f compose.obds-to-fhir.yaml -f compose.full.yaml -f compose.deco
 
 ## Enable Kafka Connect and the connector
 
+Make sure to have access to Onkostar tables `lkr_meldung`, `lkr_meldung_export` and `erkrankung`.
+
+The following SQL query will SELECT required information with columns filtered by type and containing required ICD_Version entry in `XML_DATEN`:
+
+```sql
+SELECT * FROM (
+  SELECT YEAR(e.diagnosedatum) AS YEAR, versionsnummer AS VERSIONSNUMMER, lme.id AS ID, CONVERT(lme.xml_daten using utf8) AS XML_DATEN
+    FROM lkr_meldung_export lme
+    JOIN lkr_meldung lm ON lme.lkr_meldung = lm.id
+    JOIN erkrankung e ON lm.erkrankung_id = e.id
+    WHERE typ != '-1' AND versionsnummer IS NOT NULL AND lme.XML_DATEN LIKE '%ICD_Version%'
+) o;
+```
+
 ```sh
 docker compose -f compose.obds-to-fhir.yaml -f compose.full.yaml up
 ```

--- a/docker-compose/onkostar-db-connector.json
+++ b/docker-compose/onkostar-db-connector.json
@@ -8,7 +8,7 @@
     "connection.password": "${file:/tmp/kafka-connect-passwords.properties:onkostar-db-password}",
     "schema.pattern": "ONKOSTAR",
     "topic.prefix": "onkostar.MELDUNG_EXPORT",
-    "query": "SELECT * FROM (SELECT * FROM STG_ONKOSTAR_LKR_MELDUNG_EXPORT WHERE TYP != '-1' AND VERSIONSNUMMER IS NOT NULL) o",
+    "query": "SELECT * FROM (SELECT YEAR(e.diagnosedatum) AS YEAR, versionsnummer AS VERSIONSNUMMER, lme.id AS ID, CONVERT(lme.xml_daten using utf8) AS XML_DATEN FROM lkr_meldung_export lme JOIN lkr_meldung lm ON lme.lkr_meldung = lm.id JOIN erkrankung e ON lm.erkrankung_id = e.id WHERE typ != '-1' AND versionsnummer IS NOT NULL AND lme.XML_DATEN LIKE '%ICD_Version%') o;",
     "mode": "incrementing",
     "incrementing.column.name": "ID",
     "validate.non.null": "true",


### PR DESCRIPTION
This modifies the SQL query used by the Kafka connector to search for lkr_message with diagnosis date, but filtered for those entries with type `-1` and xml data containing `ICD_Version`.

SQL query is mentioned in README.md, too.